### PR TITLE
Add more parameters to the example configuration

### DIFF
--- a/testdata/get-configuration.json
+++ b/testdata/get-configuration.json
@@ -24,6 +24,8 @@
         "relay_secret_key": "0x00",
         "optimistic_relay_secret_key": "0x00",
         "coinbase_secret_key": "0x00",
+        "top_bid_stream_api_key": "0x00",
+        "always_seal": true,
         "relays": [
             {
                 "name": "flashbots",
@@ -45,6 +47,7 @@
     },
     "prometheus": {
         "__version": "2.54.0",
+        "instance_name": "tdx-builder-xx-yocto",
         "scrape_interval": "10s",
         "static_configs_default_labels": [
             {
@@ -71,13 +74,18 @@
         "rbuilder_metrics": {
             "enabled": true,
             "targets": [
-                "localhost:6069"
+                "localhost:6060"
             ]
         },
         "remote_write": [
             {
                 "name": "tdx-rbuilder-collector",
-                "url": "https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-xxx/api/v1/remote_write"
+                "url": "https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-xxx/api/v1/remote_write",
+                "sigv4": {
+                    "access_key": "xxx",
+                    "secret_key": "xxx",
+                    "region": "us-east-2"
+                }
             }
         ]
     },


### PR DESCRIPTION
## 📝 Summary

Add more parameters to the example configuration:
- Couple of new parameters supported by the rbuilder-operator
- `instance_name` to the Prometheus config to uniquely identify the running instance
- Secrets configuration to Prometheus config to authenticate to the remote endpoint

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
