### PR TITLE
Remove local Prometheus instance name and Fluentbit stream name

### DIFF
--- a/testdata/get-configuration.json
+++ b/testdata/get-configuration.json
@@ -49,7 +49,6 @@
     },
     "prometheus": {
         "__version": "2.54.0",
-        "instance_name": "tdx-builder-xx-yocto",
         "scrape_interval": "10s",
         "static_configs_default_labels": [
             {
@@ -124,7 +123,6 @@
         "__version": "v1.9.7",
         "input_tags": "tag-1 tag-2",
         "output_cw_log_group_name": "multioperator-builder",
-        "output_cw_log_stream_name": "builder-01",
         "aws_access_key_id": "xxx",
         "aws_secret_access_key": "xxx"
     }


### PR DESCRIPTION
## 📝 Summary

Remove local Prometheus instance name and Fluentbit stream name

## ⛱ Motivation and Context

- Prometheus config will use the globally scoped instance name
- Fluentbit will construct stream name from the instance name and the log file name

## 📚 References

Companion PR: https://github.com/flashbots/meta-observability/pull/15

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
