### PR TITLE
feat: Add CI pipeline to build and push docker image to ghcr

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,40 +1,30 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*"
 
 jobs:
-  extract-version:
-    name: Extract version
-    runs-on: ubuntu-latest
-    outputs:
-      VERSION: ${{ steps.extract_version.outputs.VERSION }}
-    steps:
-      - name: Extract version
-        id: extract_version
-        run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            VERSION="${GITHUB_REF_NAME}"
-          else
-            VERSION="$(echo ${GITHUB_SHA} | cut -c1-7)"
-          fi
-          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
-
-  build-and-push:
-    name: Build and Push Docker image
-    needs: [extract-version]
+  docker-image:
+    name: Publish Docker image
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    env:
-      VERSION: ${{ needs.extract-version.outputs.VERSION }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Get tag version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Print version
+        run: |
+          echo $RELEASE_VERSION
+          echo ${{ env.RELEASE_VERSION }}
 
       - name: Set up QEMU (for multi-arch builds, optional)
         uses: docker/setup-qemu-action@v3
@@ -50,12 +40,9 @@ jobs:
           labels: org.opencontainers.image.source=${{ github.repositoryUrl }}
           tags: |
             type=sha
-            type=semver,pattern={{version}},value=${{ env.VERSION }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ env.VERSION }}
-            type=semver,pattern={{major}},value=${{ env.VERSION }}
-            
+            type=semver,pattern={{version}}
             # Also push "latest" if it's a full release (no '-' in version for rc/beta)
-            type=raw,value=latest,enable=${{ !contains(env.VERSION, '-') }}
+            type=raw,value=latest,enable=${{ !contains(env.RELEASE_VERSION, '-') }}
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -68,8 +55,10 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            VERSION=${{ env.RELEASE_VERSION }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,97 +1,76 @@
-# name: Release
+name: Release
 
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
-
-  dummy:
-    name: Dummy
+  extract-version:
+    name: Extract version
     runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.extract_version.outputs.VERSION }}
+    steps:
+      - name: Extract version
+        id: extract_version
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            VERSION="${GITHUB_REF_NAME}"
+          else
+            VERSION="$(echo ${GITHUB_SHA} | cut -c1-7)"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+
+  build-and-push:
+    name: Build and Push Docker image
+    needs: [extract-version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      VERSION: ${{ needs.extract-version.outputs.VERSION }}
 
     steps:
-      - name: Dummy
-        run: exit 0
+      - name: Checkout
+        uses: actions/checkout@v4
 
+      - name: Set up QEMU (for multi-arch builds, optional)
+        uses: docker/setup-qemu-action@v3
 
-#   docker-image:
-#     name: Publish Docker Image
-#     runs-on: ubuntu-latest
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
 
-#     steps:
-#       - name: Checkout sources
-#         uses: actions/checkout@v2
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/builder-hub
+          labels: org.opencontainers.image.source=${{ github.repositoryUrl }}
+          tags: |
+            type=sha
+            type=semver,pattern={{version}},value=${{ env.VERSION }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.VERSION }}
+            type=semver,pattern={{major}},value=${{ env.VERSION }}
+            
+            # Also push "latest" if it's a full release (no '-' in version for rc/beta)
+            type=raw,value=latest,enable=${{ !contains(env.VERSION, '-') }}
 
-#       - name: Get tag version
-#         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-#       - name: Print version
-#         run: |
-#           echo $RELEASE_VERSION
-#           echo ${{ env.RELEASE_VERSION }}
-
-#       - name: Set up QEMU
-#         uses: docker/setup-qemu-action@v3
-
-#       - name: Set up Docker Buildx
-#         uses: docker/setup-buildx-action@v3
-
-#       - name: Extract metadata (tags, labels) for Docker
-#          id: meta
-#          uses: docker/metadata-action@v5
-#          with:
-#            images: flashbots/go-template
-#            tags: |
-#              type=sha
-#              type=pep440,pattern={{version}}
-#              type=pep440,pattern={{major}}.{{minor}}
-#              type=raw,value=latest,enable=${{ !contains(env.RELEASE_VERSION, '-') }}
-
-#       - name: Login to DockerHub
-#         uses: docker/login-action@v3
-#         with:
-#           username: ${{ secrets.DOCKERHUB_USERNAME }}
-#           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-#      - name: Go Build Cache for Docker
-#        uses: actions/cache@v3
-#        with:
-#          path: go-build-cache
-#          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
-
-#      - name: inject go-build-cache into docker
-#        uses: reproducible-containers/buildkit-cache-dance@v2.1.2
-#        with:
-#          cache-source: go-build-cache
-
-#       - name: Build and push
-#         uses: docker/build-push-action@v5
-#         with:
-#           context: .
-#           build-args: |
-#             VERSION=${{ env.RELEASE_VERSION }}
-#           push: true
-#           tags: ${{ steps.meta.outputs.tags }}
-#           labels: ${{ steps.meta.outputs.labels }}
-#           platforms: linux/amd64,linux/arm64
-#           cache-from: type=gha
-#           cache-to: type=gha,mode=max
-
-#   github-release:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout sources
-#         uses: actions/checkout@v2
-
-#       - name: Create release
-#         id: create_release
-#         uses: actions/create-release@v1
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-#         with:
-#           tag_name: ${{ github.ref }}
-#           release_name: ${{ github.ref }}
-#           draft: false
-#           prerelease: false
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## 📝 Summary

This PR adds to the release.yaml a new job to build and push docker image to ghcr to be used later in other places, such as builder-playground

## ⛱ Motivation and Context

The motivation behind this is to integrate builder-hub into builder-playground as a component and build a BuilderNet recipe for local dev

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
