### PR TITLE
allow inmemory secret service for development

### DIFF
--- a/domain/inmemory_secret.go
+++ b/domain/inmemory_secret.go
@@ -1,0 +1,28 @@
+package domain
+
+import "sync"
+
+type InmemorySecretService struct {
+	mu *sync.RWMutex
+	st map[string]map[string]string
+}
+
+func NewMockSecretService() *InmemorySecretService {
+	return &InmemorySecretService{
+		st: make(map[string]map[string]string),
+		mu: &sync.RWMutex{},
+	}
+}
+
+func (mss *InmemorySecretService) GetSecretValues(builderName string) (map[string]string, error) {
+	mss.mu.RLock()
+	defer mss.mu.RUnlock()
+	return mss.st[builderName], nil
+}
+
+func (mss *InmemorySecretService) SetSecretValues(builderName string, values map[string]string) error {
+	mss.mu.Lock()
+	defer mss.mu.Unlock()
+	mss.st[builderName] = values
+	return nil
+}

--- a/httpserver/e2e_test.go
+++ b/httpserver/e2e_test.go
@@ -18,23 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type MockSecretService struct {
-	st map[string]map[string]string
-}
-
-func NewMockSecretService() *MockSecretService {
-	return &MockSecretService{st: make(map[string]map[string]string)}
-}
-
-func (mss *MockSecretService) GetSecretValues(builderName string) (map[string]string, error) {
-	return mss.st[builderName], nil
-}
-
-func (mss *MockSecretService) SetSecretValues(builderName string, values map[string]string) error {
-	mss.st[builderName] = values
-	return nil
-}
-
 func TestCreateMultipleBuilders(t *testing.T) {
 	if os.Getenv("RUN_DB_TESTS") != "1" {
 		t.Skip("skipping test; RUN_DB_TESTS is not set to 1")
@@ -238,10 +221,10 @@ func createDbService(t *testing.T) *database.Service {
 	return dbService
 }
 
-func createServer(t *testing.T) (*Server, *database.Service, *MockSecretService) {
+func createServer(t *testing.T) (*Server, *database.Service, *domain.InmemorySecretService) {
 	t.Helper()
 	dbService := createDbService(t)
-	mss := NewMockSecretService()
+	mss := domain.NewMockSecretService()
 	bhs := application.NewBuilderHub(dbService, mss)
 	bhh := ports.NewBuilderHubHandler(bhs, getTestLogger())
 	_ = bhh


### PR DESCRIPTION
## 📝 Summary

Allow simple inmemory secret management for development/local setup purposes (aws secrets manager is not mockable in a feasible way)

## ⛱ Motivation and Context

Having devnet/local setup is beneficial for overall BuilderNet ecosystem

## 📚 References

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
