### PR TITLE
docker version fix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,13 +20,15 @@ jobs:
 
       - name: Get tag and SHA version
         run: |
-          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-          echo "GIT_SHA=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          echo "GITHUB_REF=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "GIT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+          echo "BINARY_VERSION=${GITHUB_REF}-${GIT_SHA}" >> $GITHUB_ENV
 
       - name: Print versions
         run: |
-          echo "RELEASE_VERSION: ${{ env.RELEASE_VERSION }}"
+          echo "GITHUB_REF: ${{ env.GITHUB_REF }}"
           echo "GIT_SHA: ${{ env.GIT_SHA }}"
+          echo "BINARY_VERSION: ${{ env.BINARY_VERSION }}"
 
       - name: Generate Docker metadata
         id: meta
@@ -67,7 +69,7 @@ jobs:
           context: .
           push: true
           build-args: |
-            VERSION=${{ env.RELEASE_VERSION }}-${{ env.GIT_SHA }}
+            VERSION=${{ env.BINARY_VERSION }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Always a bit cumbersome to test CI release steps, and in particular Docker, because of the need to merge and deploy them before executing.