### PR TITLE
Separate builders by networks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+docker/httpserver/Dockerfile

--- a/adapters/database/types.go
+++ b/adapters/database/types.go
@@ -44,6 +44,7 @@ type Builder struct {
 	Name         string      `db:"name"`
 	IPAddress    pgtype.Inet `db:"ip_address"`
 	IsActive     bool        `db:"is_active"`
+	Network      string      `db:"network"`
 	CreatedAt    time.Time   `db:"created_at"`
 	UpdatedAt    time.Time   `db:"updated_at"`
 	DeprecatedAt *time.Time  `db:"deprecated_at"`
@@ -57,6 +58,7 @@ func convertBuilderToDomain(builder Builder) (*domain.Builder, error) {
 		Name:      builder.Name,
 		IPAddress: builder.IPAddress.IPNet.IP,
 		IsActive:  builder.IsActive,
+		Network:   builder.Network,
 	}, nil
 }
 

--- a/application/service.go
+++ b/application/service.go
@@ -11,7 +11,7 @@ import (
 
 type BuilderDataAccessor interface {
 	GetActiveMeasurements(ctx context.Context) ([]domain.Measurement, error)
-	GetActiveBuildersWithServiceCredentials(ctx context.Context) ([]domain.BuilderWithServices, error)
+	GetActiveBuildersWithServiceCredentials(ctx context.Context, network string) ([]domain.BuilderWithServices, error)
 	GetActiveMeasurementsByType(ctx context.Context, attestationType string) ([]domain.Measurement, error)
 	GetBuilderByIP(ip net.IP) (*domain.Builder, error)
 	GetActiveConfigForBuilder(ctx context.Context, builderName string) (json.RawMessage, error)
@@ -36,8 +36,8 @@ func (b *BuilderHub) GetAllowedMeasurements(ctx context.Context) ([]domain.Measu
 	return b.dataAccessor.GetActiveMeasurements(ctx)
 }
 
-func (b *BuilderHub) GetActiveBuilders(ctx context.Context) ([]domain.BuilderWithServices, error) {
-	return b.dataAccessor.GetActiveBuildersWithServiceCredentials(ctx)
+func (b *BuilderHub) GetActiveBuilders(ctx context.Context, network string) ([]domain.BuilderWithServices, error) {
+	return b.dataAccessor.GetActiveBuildersWithServiceCredentials(ctx, network)
 }
 
 func (b *BuilderHub) LogEvent(ctx context.Context, eventName, builderName, name string) error {

--- a/docs/api-docs/admin-api/Add new builder.bru
+++ b/docs/api-docs/admin-api/Add new builder.bru
@@ -13,6 +13,7 @@ post {
 body:json {
   {
     "name": "{builder}",
-    "ip_address": "{ip_address}"
+    "ip_address": "{ip_address}",
+    "network": "{network}"
   }
 }

--- a/domain/types.go
+++ b/domain/types.go
@@ -14,6 +14,8 @@ var (
 	ErrInvalidMeasurement = errors.New("no such active measurement found")
 )
 
+const ProductionNetwork = "production"
+
 const EventGetConfig = "GetConfig"
 
 type Measurement struct {
@@ -38,6 +40,7 @@ type Builder struct {
 	Name      string `json:"name"`
 	IPAddress net.IP `json:"ip_address"`
 	IsActive  bool   `json:"is_active"`
+	Network   string `json:"network"`
 }
 
 type BuilderWithServices struct {

--- a/httpserver/server.go
+++ b/httpserver/server.go
@@ -97,6 +97,7 @@ func (srv *Server) GetRouter() http.Handler {
 	mux.Get("/api/l1-builder/v1/builders", srv.appHandler.GetActiveBuilders)
 	mux.Post("/api/l1-builder/v1/register_credentials/{service}", srv.appHandler.RegisterCredentials)
 	mux.Get("/api/internal/l1-builder/v1/builders", srv.appHandler.GetActiveBuildersNoAuth)
+	mux.Get("/api/internal/l1-builder/v2/network/{network}/builders", srv.appHandler.GetActiveBuildersNoAuthNetworked)
 	if srv.cfg.EnablePprof {
 		srv.log.Info("pprof API enabled")
 		mux.Mount("/debug", middleware.Profiler())
@@ -133,6 +134,7 @@ func (srv *Server) GetInternalRouter() http.Handler {
 
 	mux.Get("/api/l1-builder/v1/measurements", srv.appHandler.GetAllowedMeasurements)
 	mux.Get("/api/internal/l1-builder/v1/builders", srv.appHandler.GetActiveBuildersNoAuth)
+	mux.Get("/api/internal/l1-builder/v2/network/{network}/builders", srv.appHandler.GetActiveBuildersNoAuthNetworked)
 
 	return mux
 }

--- a/ports/admin_handler.go
+++ b/ports/admin_handler.go
@@ -126,7 +126,7 @@ func (s *AdminHandler) AddBuilder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if builder.Network == "" {
-		s.log.Error("Failed to unmarshal request body", "err", err)
+		s.log.Error("network field is required")
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte("network field is required"))
 		return

--- a/ports/admin_handler.go
+++ b/ports/admin_handler.go
@@ -125,6 +125,12 @@ func (s *AdminHandler) AddBuilder(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	if builder.Network == "" {
+		s.log.Error("Failed to unmarshal request body", "err", err)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("network field is required"))
+		return
+	}
 	dBuilder, err := toDomainBuilder(builder, false)
 	if err != nil {
 		s.log.Error("Failed to convert builder to domain builder", "err", err)

--- a/ports/types.go
+++ b/ports/types.go
@@ -132,6 +132,7 @@ func toDomainMeasurement(measurement Measurement) domain.Measurement {
 type Builder struct {
 	Name      string `json:"name"`
 	IPAddress string `json:"ip_address"`
+	Network   string `json:"network"`
 }
 
 func toDomainBuilder(builder Builder, enabled bool) (domain.Builder, error) {
@@ -144,5 +145,6 @@ func toDomainBuilder(builder Builder, enabled bool) (domain.Builder, error) {
 		Name:      builder.Name,
 		IPAddress: ip,
 		IsActive:  enabled,
+		Network:   builder.Network,
 	}, nil
 }

--- a/schema/002_network_builder.sql
+++ b/schema/002_network_builder.sql
@@ -1,0 +1,2 @@
+ALTER TABLE builders
+    ADD COLUMN network TEXT NOT NULL DEFAULT 'production';


### PR DESCRIPTION

## 📝 Summary

1. Support multi-tenant setup split by networks
2. Admin API for builder creation now requires `network` field
3. Get Active Builders requests now returns only builders within the same network
4. Internal endpoint v1 defaults to `production` network
5. Internal endpoint v2 takes network from url param


## ⛱ Motivation and Context

For ease of setup of staging networks which should not share orderflow with the main builderNet env

## 📚 References

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
