### PR TITLE
Configurable watchdog timeout for rbuilder

### DIFF
--- a/testdata/get-configuration.json
+++ b/testdata/get-configuration.json
@@ -38,7 +38,8 @@
         "require_non_empty_blocklist": false,
         "top_bid_stream_api_key": "0x00",
         "top_bid_ws_basic_auth": "Zmxhc2hib3RzOmRvbnRwZWVrb25tZQ==",
-        "top_bid_ws_url": "ws://localhost:8546"
+        "top_bid_ws_url": "ws://localhost:8546",
+        "watchdog_timeout_sec": 145
     },
     "disk_encryption": {
         "key": "string"


### PR DESCRIPTION
## 📝 Summary

Configurable watchdog timeout for rbuilder

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
