### PR TITLE
Support `dns_name` for `builders`.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.21
+          go-version: ^1.24
         id: go
 
       - name: Check out code into the Go module directory
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.22
+          go-version: ^1.24
         id: go
 
       - name: Check out code into the Go module directory
@@ -58,10 +58,10 @@ jobs:
         run: go install mvdan.cc/gofumpt@v0.4.0
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@2024.1.1
+        run: go install honnef.co/go/tools/cmd/staticcheck@2025.1.1
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
 
       - name: Install NilAway
         run: go install go.uber.org/nilaway/cmd/nilaway@v0.0.0-20240821220108-c91e71c080b7

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,7 +12,6 @@ linters:
     - gocritic
     - godot
     - godox
-    - gomnd
     - lll
     - nestif
     - nilnil
@@ -44,8 +43,7 @@ linters:
     #
     # Disabled because deprecated:
     #
-    - execinquery
-    - exportloopref
+    - tenv
 
 linters-settings:
   #

--- a/README.md
+++ b/README.md
@@ -124,12 +124,18 @@ Auth:
 
 Request:
 
-- [service: `orderflow_proxy`]:
-    - TLS cert + ECDSA pubkey address (for orderflow)
+- [service: `instance`]: TLS cert
 
     ```json
     {
     	"tls_cert": string (\n instead of newlines)
+    }
+    ```
+
+- [service: `orderflow_proxy`]: ECDSA pubkey address (for orderflow)
+
+    ```json
+    {
     	"ecdsa_pubkey_address": string
     }
     ```

--- a/adapters/database/types.go
+++ b/adapters/database/types.go
@@ -9,14 +9,6 @@ import (
 	"github.com/jackc/pgtype"
 )
 
-type ActiveBuilder struct {
-	BuilderID   int         `db:"builder_id"`
-	Name        string      `db:"name"`
-	IPAddress   pgtype.Inet `db:"ip_address"`
-	TLSPubKey   []byte      `db:"tls_pubkey"`
-	ECDSAPubKey []byte      `db:"ecdsa_pubkey"`
-}
-
 type Measurement struct {
 	ID              int             `db:"id"`
 	Name            string          `db:"name"`
@@ -41,13 +33,14 @@ func convertMeasurementToDomain(measurement Measurement) (*domain.Measurement, e
 }
 
 type Builder struct {
-	Name         string      `db:"name"`
-	IPAddress    pgtype.Inet `db:"ip_address"`
-	IsActive     bool        `db:"is_active"`
-	Network      string      `db:"network"`
-	CreatedAt    time.Time   `db:"created_at"`
-	UpdatedAt    time.Time   `db:"updated_at"`
-	DeprecatedAt *time.Time  `db:"deprecated_at"`
+	Name         string         `db:"name"`
+	IPAddress    pgtype.Inet    `db:"ip_address"`
+	IsActive     bool           `db:"is_active"`
+	Network      string         `db:"network"`
+	DNSNAme      sql.NullString `db:"dns_name"`
+	CreatedAt    time.Time      `db:"created_at"`
+	UpdatedAt    time.Time      `db:"updated_at"`
+	DeprecatedAt *time.Time     `db:"deprecated_at"`
 }
 
 func convertBuilderToDomain(builder Builder) (*domain.Builder, error) {
@@ -59,6 +52,7 @@ func convertBuilderToDomain(builder Builder) (*domain.Builder, error) {
 		IPAddress: builder.IPAddress.IPNet.IP,
 		IsActive:  builder.IsActive,
 		Network:   builder.Network,
+		DNSName:   builder.DNSNAme.String,
 	}, nil
 }
 
@@ -83,6 +77,7 @@ type BuilderConfig struct {
 type BuilderWithCredentials struct {
 	Name        string
 	IPAddress   pgtype.Inet
+	DNSName     sql.NullString
 	Credentials []ServiceCredential
 }
 type ServiceCredential struct {
@@ -98,6 +93,7 @@ func toDomainBuilderWithCredentials(builder BuilderWithCredentials) (*domain.Bui
 	s := domain.BuilderWithServices{
 		Builder: domain.Builder{
 			Name:      builder.Name,
+			DNSName:   builder.DNSName.String,
 			IPAddress: builder.IPAddress.IPNet.IP,
 			IsActive:  true,
 		},

--- a/adapters/database/types.go
+++ b/adapters/database/types.go
@@ -37,7 +37,7 @@ type Builder struct {
 	IPAddress    pgtype.Inet    `db:"ip_address"`
 	IsActive     bool           `db:"is_active"`
 	Network      string         `db:"network"`
-	DNSNAme      sql.NullString `db:"dns_name"`
+	DNSName      sql.NullString `db:"dns_name"`
 	CreatedAt    time.Time      `db:"created_at"`
 	UpdatedAt    time.Time      `db:"updated_at"`
 	DeprecatedAt *time.Time     `db:"deprecated_at"`
@@ -52,7 +52,7 @@ func convertBuilderToDomain(builder Builder) (*domain.Builder, error) {
 		IPAddress: builder.IPAddress.IPNet.IP,
 		IsActive:  builder.IsActive,
 		Network:   builder.Network,
-		DNSName:   builder.DNSNAme.String,
+		DNSName:   builder.DNSName.String,
 	}, nil
 }
 

--- a/docs/api-docs/admin-api/Add new builder.bru
+++ b/docs/api-docs/admin-api/Add new builder.bru
@@ -14,6 +14,7 @@ body:json {
   {
     "name": "{builder}",
     "ip_address": "{ip_address}",
+    "dns_name": "{dns_name}",
     "network": "{network}"
   }
 }

--- a/domain/types.go
+++ b/domain/types.go
@@ -41,6 +41,7 @@ type Builder struct {
 	IPAddress net.IP `json:"ip_address"`
 	IsActive  bool   `json:"is_active"`
 	Network   string `json:"network"`
+	DNSName   string `json:"dns_name"`
 }
 
 type BuilderWithServices struct {

--- a/httpserver/e2e_test.go
+++ b/httpserver/e2e_test.go
@@ -221,6 +221,7 @@ func TestAuthInteractionFlow(t *testing.T) {
 		require.Equal(t, http.StatusOK, sc)
 		require.Equal(t, 1, len(resp))
 		require.Equal(t, builderName, resp[0].Name)
+		require.Equal(t, builderName+".builder.net", resp[0].DNSName)
 		require.Equal(t, "test-cert-no-validation", resp[0].ServiceCreds["rbuilder"].TLSCert)
 		require.Equal(t, "0x1234567890123456789012345678901234567890", resp[0].ServiceCreds["rbuilder"].ECDSAPubkey.String())
 	})
@@ -228,9 +229,11 @@ func TestAuthInteractionFlow(t *testing.T) {
 
 // createBuilder emulates admin flow to provision a builder
 func createBuilder(t *testing.T, s *Server, builderName, ip, network string) {
+	dnsName := builderName + ".builder.net"
 	builder := ports.Builder{
 		Name:      builderName,
 		IPAddress: ip,
+		DNSName:   dnsName,
 		Network:   network,
 	}
 	t.Run("CreateBuilder", func(t *testing.T) {
@@ -264,6 +267,7 @@ func createBuilder(t *testing.T, s *Server, builderName, ip, network string) {
 		for _, b := range resp {
 			if b.Name == builderName {
 				require.Equal(t, ip, b.IP)
+				require.Equal(t, dnsName, b.DNSName)
 				return
 			}
 		}

--- a/ports/types.go
+++ b/ports/types.go
@@ -23,6 +23,7 @@ var (
 
 type BuilderWithServiceCreds struct {
 	IP           string
+	DNSName      string
 	Name         string
 	ServiceCreds map[string]ServiceCred
 }
@@ -41,6 +42,7 @@ func (b BuilderWithServiceCreds) MarshalJSON() ([]byte, error) {
 	// Add the IP field
 	m["ip"] = b.IP
 	m["name"] = b.Name
+	m["dns_name"] = b.DNSName
 
 	// Add all services
 	for k, v := range b.ServiceCreds {
@@ -54,8 +56,9 @@ func (b BuilderWithServiceCreds) MarshalJSON() ([]byte, error) {
 func (b *BuilderWithServiceCreds) UnmarshalJSON(data []byte) error {
 	// Define a temporary struct to unmarshal known fields
 	type Alias struct {
-		IP   string `json:"ip"`
-		Name string `json:"name"`
+		IP      string `json:"ip"`
+		Name    string `json:"name"`
+		DNSName string `json:"dns_name"`
 	}
 
 	// Unmarshal known fields first
@@ -67,6 +70,7 @@ func (b *BuilderWithServiceCreds) UnmarshalJSON(data []byte) error {
 	// Copy known fields to the original struct
 	b.IP = alias.IP
 	b.Name = alias.Name
+	b.DNSName = alias.DNSName
 
 	// Unmarshal the remaining fields into a map
 	var rawMap map[string]json.RawMessage
@@ -77,6 +81,7 @@ func (b *BuilderWithServiceCreds) UnmarshalJSON(data []byte) error {
 	// Remove known fields from the map
 	delete(rawMap, "ip")
 	delete(rawMap, "name")
+	delete(rawMap, "dns_name")
 
 	// Initialize the ServiceCreds map
 	b.ServiceCreds = make(map[string]ServiceCred)
@@ -98,6 +103,8 @@ func fromDomainBuilderWithServices(builder domain.BuilderWithServices) BuilderWi
 
 	b.IP = builder.Builder.IPAddress.String()
 	b.Name = builder.Builder.Name
+	b.DNSName = builder.Builder.DNSName
+
 	b.ServiceCreds = make(map[string]ServiceCred)
 	for _, v := range builder.Services {
 		b.ServiceCreds[v.Service] = ServiceCred{
@@ -131,6 +138,7 @@ func toDomainMeasurement(measurement Measurement) domain.Measurement {
 
 type Builder struct {
 	Name      string `json:"name"`
+	DNSName   string `json:"dns_name"`
 	IPAddress string `json:"ip_address"`
 	Network   string `json:"network"`
 }
@@ -143,6 +151,7 @@ func toDomainBuilder(builder Builder, enabled bool) (domain.Builder, error) {
 
 	return domain.Builder{
 		Name:      builder.Name,
+		DNSName:   builder.DNSName,
 		IPAddress: ip,
 		IsActive:  enabled,
 		Network:   builder.Network,

--- a/schema/003_builder_dns_name.sql
+++ b/schema/003_builder_dns_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE builders
+    ADD COLUMN dns_name TEXT;


### PR DESCRIPTION
## 📝 Summary

Allows to configure `dns_name` along with `ip` for new builder instances

## ⛱ Motivation and Context

Moving from ips and self-signed certs to let's encrypt issued certs

## 📚 References

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
