### PR TITLE
Allow separately register instance service

### DIFF
--- a/httpserver/e2e_test.go
+++ b/httpserver/e2e_test.go
@@ -207,7 +207,6 @@ func TestAuthInteractionFlow(t *testing.T) {
 	t.Run("RegisterCredentials", func(t *testing.T) {
 		addr := common.HexToAddress("0x1234567890123456789012345678901234567890")
 		sc := ports.ServiceCred{
-			TLSCert:     "test-cert-no-validation",
 			ECDSAPubkey: &addr,
 		}
 		status, _ := execRequestAuth(t, s.GetRouter(), http.MethodPost, "/api/l1-builder/v1/register_credentials/rbuilder", sc, nil, measurement.AttestationType, map[string]string{"8": "0000000000000000000000000000000000000000000000000000000000000000", "11": "efa43e0beff151b0f251c4abf48152382b1452b4414dbd737b4127de05ca31f7"}, "127.0.0.1")
@@ -222,7 +221,7 @@ func TestAuthInteractionFlow(t *testing.T) {
 		require.Equal(t, 1, len(resp))
 		require.Equal(t, builderName, resp[0].Name)
 		require.Equal(t, builderName+".builder.net", resp[0].DNSName)
-		require.Equal(t, "test-cert-no-validation", resp[0].ServiceCreds["rbuilder"].TLSCert)
+		require.Equal(t, "", resp[0].ServiceCreds["rbuilder"].TLSCert)
 		require.Equal(t, "0x1234567890123456789012345678901234567890", resp[0].ServiceCreds["rbuilder"].ECDSAPubkey.String())
 	})
 }

--- a/ports/http_handler.go
+++ b/ports/http_handler.go
@@ -277,34 +277,19 @@ func (bhs *BuilderHubHandler) RegisterCredentials(w http.ResponseWriter, r *http
 	switch service {
 	case "instance":
 		if sc.TLSCert == "" {
-			errMsg := "TLS certificate is required for instance service"
-			bhs.log.Warn(errMsg)
-			w.WriteHeader(http.StatusBadRequest)
-			if _, err := w.Write([]byte(errMsg)); err != nil {
-				bhs.log.Error("failed to write response", "error", err)
-			}
+			http.Error(w, "TLS cert is required for instance service", http.StatusBadRequest)
 			return
 		}
 		tlsCert = sc.TLSCert
 	case "orderflow_proxy", "rbuilder":
 		if sc.ECDSAPubkey == nil {
-			errMsg := "ECDSA pubkey is required for service"
-			bhs.log.Warn(errMsg, "service", service)
-			w.WriteHeader(http.StatusBadRequest)
-			if _, err := w.Write([]byte(errMsg)); err != nil {
-				bhs.log.Error("failed to write response", "error", err)
-			}
+			http.Error(w, "ECDSA pubkey is required for service", http.StatusBadRequest)
 			return
 		}
 		ecdsaPubkey = sc.ECDSAPubkey.Bytes()
 	default:
 		if sc.TLSCert == "" && sc.ECDSAPubkey == nil {
-			errMsg := "No credentials provided"
-			bhs.log.Warn(errMsg)
-			w.WriteHeader(http.StatusBadRequest)
-			if _, err := w.Write([]byte(errMsg)); err != nil {
-				bhs.log.Error("failed to write response", "error", err)
-			}
+			http.Error(w, "No credentials provided", http.StatusBadRequest)
 			return
 		}
 		tlsCert = sc.TLSCert

--- a/ports/http_handler.go
+++ b/ports/http_handler.go
@@ -280,7 +280,9 @@ func (bhs *BuilderHubHandler) RegisterCredentials(w http.ResponseWriter, r *http
 			errMsg := "TLS certificate is required for instance service"
 			bhs.log.Warn(errMsg)
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte(errMsg))
+			if _, err := w.Write([]byte(errMsg)); err != nil {
+				bhs.log.Error("failed to write response", "error", err)
+			}
 			return
 		}
 		tlsCert = sc.TLSCert
@@ -289,7 +291,9 @@ func (bhs *BuilderHubHandler) RegisterCredentials(w http.ResponseWriter, r *http
 			errMsg := "ECDSA pubkey is required for service"
 			bhs.log.Warn(errMsg, "service", service)
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte(errMsg))
+			if _, err := w.Write([]byte(errMsg)); err != nil {
+				bhs.log.Error("failed to write response", "error", err)
+			}
 			return
 		}
 		ecdsaPubkey = sc.ECDSAPubkey.Bytes()
@@ -298,7 +302,9 @@ func (bhs *BuilderHubHandler) RegisterCredentials(w http.ResponseWriter, r *http
 			errMsg := "No credentials provided"
 			bhs.log.Warn(errMsg)
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte(errMsg))
+			if _, err := w.Write([]byte(errMsg)); err != nil {
+				bhs.log.Error("failed to write response", "error", err)
+			}
 			return
 		}
 		tlsCert = sc.TLSCert

--- a/ports/http_handler.go
+++ b/ports/http_handler.go
@@ -290,9 +290,13 @@ func (bhs *BuilderHubHandler) RegisterCredentials(w http.ResponseWriter, r *http
 		}
 		ecdsaPubkey = sc.ECDSAPubkey.Bytes()
 	default:
-		bhs.log.Error("Unknown service type", "service", service)
-		w.WriteHeader(http.StatusBadRequest)
-		return
+		if sc.TLSCert == "" && sc.ECDSAPubkey == nil {
+			bhs.log.Error("No credentials provided")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		tlsCert = sc.TLSCert
+		ecdsaPubkey = sc.ECDSAPubkey.Bytes()
 	}
 
 	err = bhs.builderHubService.RegisterCredentialsForBuilder(r.Context(), builder.Name, service, tlsCert, ecdsaPubkey, measurementName, authData.AttestationType)

--- a/ports/http_handler.go
+++ b/ports/http_handler.go
@@ -277,22 +277,28 @@ func (bhs *BuilderHubHandler) RegisterCredentials(w http.ResponseWriter, r *http
 	switch service {
 	case "instance":
 		if sc.TLSCert == "" {
-			bhs.log.Error("TLS cert is required for instance service")
+			errMsg := "TLS certificate is required for instance service"
+			bhs.log.Warn(errMsg)
 			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(errMsg))
 			return
 		}
 		tlsCert = sc.TLSCert
 	case "orderflow_proxy", "rbuilder":
 		if sc.ECDSAPubkey == nil {
-			bhs.log.Error("ECDSA pubkey is required for service", "service", service)
+			errMsg := "ECDSA pubkey is required for service"
+			bhs.log.Warn(errMsg, "service", service)
 			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(errMsg))
 			return
 		}
 		ecdsaPubkey = sc.ECDSAPubkey.Bytes()
 	default:
 		if sc.TLSCert == "" && sc.ECDSAPubkey == nil {
-			bhs.log.Error("No credentials provided")
+			errMsg := "No credentials provided"
+			bhs.log.Warn(errMsg)
 			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(errMsg))
 			return
 		}
 		tlsCert = sc.TLSCert


### PR DESCRIPTION
## 📝 Summary

Fix nil pointer dereference when attempting to `sc.ECDSAPubkey.Bytes()` on the nil string when calling `api/l1-builder/v1/register_credentials/instance` endpoint. The endpoint does not contain `ECDSAPubkey` in the request body.

## ⛱ Motivation and Context

nil pointer dereference when attempting to `sc.ECDSAPubkey.Bytes()` on the nil string
```
goroutine 9 [running]:runtime/debug.Stack()    runtime/debug/stack.go:26 +0x5e
github.com/go-chi/chi/v5/middleware.Recoverer.func1.1()
    github.com/go-chi/chi/v5@v5.1.0/middleware/recoverer.go:34 +0x9a
panic({0xbcc100?, 0x13bd600?})
    runtime/panic.go:791 +0x132
github.com/flashbots/builder-hub/ports.(*BuilderHubHandler).RegisterCredentials(0xc0000124c8, {0x7ff6e7caf5d8, 0xc0003dac40}, 0xc000581b80)
    github.com/flashbots/builder-hub/ports/http_handler.go:278 +0x6be
net/http.HandlerFunc.ServeHTTP(0xc0004be2d0?, {0x7ff6e7caf5d8?, 0xc0003dac40?}, 0xc00002e8c5?)
    net/http/server.go:2220 +0x29
github.com/go-chi/chi/v5.(*Mux).routeHTTP(0xc00007e6c0, {0x7ff6e7caf5d8, 0xc0003dac40}, 0xc000581b80)
    github.com/go-chi/chi/v5@v5.1.0/mux.go:459 +0x2e2
net/http.HandlerFunc.ServeHTTP(0x4169ab?, {0x7ff6e7caf5d8?, 0xc0003dac40?}, 0x140?)
    net/http/server.go:2220 +0x29
github.com/flashbots/builder-hub/metrics.Middleware.func1({0x7ff6e7caf5d8, 0xc0003dac40}, 0xc000581b80)
    github.com/flashbots/builder-hub/metrics/middleware.go:18 +0xa2
net/http.HandlerFunc.ServeHTTP(0x47103d?, {0x7ff6e7caf5d8?, 0xc0003dac40?}, 0x40?)
    net/http/server.go:2220 +0x29
github.com/go-chi/chi/v5/middleware.Recoverer.func1({0x7ff6e7caf5d8?, 0xc0003dac40?}, 0x0?)
    github.com/go-chi/chi/v5@v5.1.0/middleware/recoverer.go:45 +0x6c
net/http.HandlerFunc.ServeHTTP(0x412205?, {0x7ff6e7caf5d8?, 0xc0003dac40?}, 0x13be701?)
    net/http/server.go:2220 +0x29
github.com/go-chi/chi/v5/middleware.Recoverer.func1({0x7ff6e7caf5d8?, 0xc0003dac40?}, 0xc0000af290?)
    github.com/go-chi/chi/v5@v5.1.0/middleware/recoverer.go:45 +0x6c
net/http.HandlerFunc.ServeHTTP(0x13bf700?, {0x7ff6e7caf5d8?, 0xc0003dac40?}, 0xc0000f7938?)
    net/http/server.go:2220 +0x29
github.com/flashbots/builder-hub/httpserver.(*Server).GetRouter.RequestLogger.Handler.func2.1({0xeb3a10, 0xc0001a2a80}, 0xc000581680)
    github.com/go-chi/httplog/v2@v2.1.1/httplog.go:111 +0x416
net/http.HandlerFunc.ServeHTTP(0xeb4570?, {0xeb3a10?, 0xc0001a2a80?}, 0xea9998?)
    net/http/server.go:2220 +0x29
github.com/go-chi/chi/v5/middleware.RequestID.func1({0xeb3a10, 0xc0001a2a80}, 0xc000581540)
    github.com/go-chi/chi/v5@v5.1.0/middleware/request_id.go:76 +0x20e
net/http.HandlerFunc.ServeHTTP(0x412205?, {0xeb3a10?, 0xc0001a2a80?}, 0x13be701?)
    net/http/server.go:2220 +0x29
github.com/go-chi/chi/v5.(*ChainHandler).ServeHTTP(0xeb45a8?, {0xeb3a10?, 0xc0001a2a80?}, 0x13be740?)
    github.com/go-chi/chi/v5@v5.1.0/chain.go:31 +0x26
github.com/go-chi/chi/v5.(*Mux).ServeHTTP(0xc00007e6c0, {0xeb3a10, 0xc0001a2a80}, 0xc000581400)
    github.com/go-chi/chi/v5@v5.1.0/mux.go:90 +0x2ee
net/http.serverHandler.ServeHTTP({0xeb0980?}, {0xeb3a10?, 0xc0001a2a80?}, 0x6?)
    net/http/server.go:3210 +0x8e
net/http.(*conn).serve(0xc0003c9b00, {0xeb4570, 0xc000426780})
    net/http/server.go:2092 +0x5d0
created by net/http.(*Server).Serve in goroutine 33
    net/http/server.go:3360 +0x485
","panic":"runtime error: invalid memory address or nil pointer dereference","httpResponse":{"status":500,"bytes":0,"elapsed":2.353897


```

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
