### PR TITLE
Allow configuring Vault auth mount path

### DIFF
--- a/adapters/secrets/hashicorp_vault.go
+++ b/adapters/secrets/hashicorp_vault.go
@@ -24,9 +24,10 @@ type VaultConfig struct {
 	Token        string // Vault token for authentication (used when AuthMethod=="token")
 	SecretPrefix string // Path prefix for secrets (e.g., "secrets/builder-hub")
 	MountPath    string // Vault KV v2 mount path (e.g., "secret", defaults to "secret")
-	AuthMethod   string // "token" (default) or "kubernetes"
-	Role         string // Role name for Kubernetes auth (required if AuthMethod=="kubernetes")
-	Jwt          string // ServiceAccount JWT for Kubernetes auth (required if AuthMethod=="kubernetes")
+	AuthMethod    string // "token" (default) or "kubernetes"
+	AuthMountPath string // Vault auth mount path for Kubernetes auth (e.g., "k8s/eth-l1-prod", defaults to "kubernetes")
+	Role          string // Role name for Kubernetes auth (required if AuthMethod=="kubernetes")
+	Jwt           string // ServiceAccount JWT for Kubernetes auth (required if AuthMethod=="kubernetes")
 }
 
 func NewHashicorpVaultService(ctx context.Context, log *slog.Logger, cfg VaultConfig) (*hashicorpVaultService, error) {
@@ -56,7 +57,11 @@ func NewHashicorpVaultService(ctx context.Context, log *slog.Logger, cfg VaultCo
 		if cfg.Jwt == "" {
 			return nil, fmt.Errorf("JWT is required for Kubernetes auth")
 		}
-		k8sAuth, err := authkubernetes.NewKubernetesAuth(cfg.Role, authkubernetes.WithServiceAccountToken(cfg.Jwt))
+		k8sAuthOpts := []authkubernetes.LoginOption{authkubernetes.WithServiceAccountToken(cfg.Jwt)}
+		if cfg.AuthMountPath != "" {
+			k8sAuthOpts = append(k8sAuthOpts, authkubernetes.WithMountPath(cfg.AuthMountPath))
+		}
+		k8sAuth, err := authkubernetes.NewKubernetesAuth(cfg.Role, k8sAuthOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize Kubernetes auth: %w", err)
 		}

--- a/adapters/secrets/hashicorp_vault.go
+++ b/adapters/secrets/hashicorp_vault.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	vault "github.com/hashicorp/vault/api"
 	authkubernetes "github.com/hashicorp/vault/api/auth/kubernetes"
@@ -105,11 +104,7 @@ func (s *hashicorpVaultService) watchTokenRenewal(ctx context.Context, watcher *
 
 func isVault404(err error) bool {
 	var responseErr *vault.ResponseError
-	if errors.As(err, &responseErr) && responseErr.StatusCode == 404 {
-		return true
-	}
-	// KVv2().Get() wraps 404 as "secret not found" without a ResponseError
-	return strings.Contains(err.Error(), "secret not found")
+	return errors.As(err, &responseErr) && responseErr.StatusCode == 404
 }
 
 func (s *hashicorpVaultService) secretKVPath(builderName string) string {

--- a/adapters/secrets/hashicorp_vault.go
+++ b/adapters/secrets/hashicorp_vault.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"time"
+	"strings"
 
 	vault "github.com/hashicorp/vault/api"
 	authkubernetes "github.com/hashicorp/vault/api/auth/kubernetes"
@@ -81,14 +81,6 @@ func NewHashicorpVaultService(ctx context.Context, log *slog.Logger, cfg VaultCo
 		client.SetToken(cfg.Token)
 	}
 
-	// Verify connection by attempting a read (404 is fine — path may not exist yet)
-	verifyCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	_, verifyErr := client.KVv2(cfg.MountPath).Get(verifyCtx, cfg.SecretPrefix)
-	if verifyErr != nil && !isVault404(verifyErr) {
-		return nil, fmt.Errorf("failed to verify Vault connection: %w", verifyErr)
-	}
-
 	return svc, nil
 }
 
@@ -113,7 +105,11 @@ func (s *hashicorpVaultService) watchTokenRenewal(ctx context.Context, watcher *
 
 func isVault404(err error) bool {
 	var responseErr *vault.ResponseError
-	return errors.As(err, &responseErr) && responseErr.StatusCode == 404
+	if errors.As(err, &responseErr) && responseErr.StatusCode == 404 {
+		return true
+	}
+	// KVv2().Get() wraps 404 as "secret not found" without a ResponseError
+	return strings.Contains(err.Error(), "secret not found")
 }
 
 func (s *hashicorpVaultService) secretKVPath(builderName string) string {

--- a/adapters/secrets/hashicorp_vault.go
+++ b/adapters/secrets/hashicorp_vault.go
@@ -20,10 +20,10 @@ type hashicorpVaultService struct {
 }
 
 type VaultConfig struct {
-	Address      string // Vault server address (e.g., http://localhost:8200)
-	Token        string // Vault token for authentication (used when AuthMethod=="token")
-	SecretPrefix string // Path prefix for secrets (e.g., "secrets/builder-hub")
-	MountPath    string // Vault KV v2 mount path (e.g., "secret", defaults to "secret")
+	Address       string // Vault server address (e.g., http://localhost:8200)
+	Token         string // Vault token for authentication (used when AuthMethod=="token")
+	SecretPrefix  string // Path prefix for secrets (e.g., "secrets/builder-hub")
+	MountPath     string // Vault KV v2 mount path (e.g., "secret", defaults to "secret")
 	AuthMethod    string // "token" (default) or "kubernetes"
 	AuthMountPath string // Vault auth mount path for Kubernetes auth (e.g., "k8s/eth-l1-prod", defaults to "kubernetes")
 	Role          string // Role name for Kubernetes auth (required if AuthMethod=="kubernetes")

--- a/cmd/httpserver/main.go
+++ b/cmd/httpserver/main.go
@@ -136,6 +136,12 @@ var flags = []cli.Flag{
 		EnvVars: []string{"VAULT_KUBERNETES_ROLE"},
 	},
 	&cli.StringFlag{
+		Name:    "vault-kubernetes-auth-path",
+		Value:   "",
+		Usage:   "Vault auth mount path for Kubernetes auth (e.g., 'k8s/eth-l1-prod', defaults to 'kubernetes')",
+		EnvVars: []string{"VAULT_KUBERNETES_AUTH_PATH"},
+	},
+	&cli.StringFlag{
 		Name:    "vault-kubernetes-jwt-path",
 		Value:   "/var/run/secrets/kubernetes.io/serviceaccount/token",
 		Usage:   "Path to ServiceAccount JWT for Kubernetes auth",
@@ -206,6 +212,7 @@ func runCli(cCtx *cli.Context) error {
 	vaultMountPath := cCtx.String("vault-mount-path")
 	vaultAuthMethod := cCtx.String("vault-auth-method")
 	vaultRole := cCtx.String("vault-kubernetes-role")
+	vaultAuthMountPath := cCtx.String("vault-kubernetes-auth-path")
 	vaultJwtPath := cCtx.String("vault-kubernetes-jwt-path")
 
 	logTags := map[string]string{
@@ -260,13 +267,14 @@ func runCli(cCtx *cli.Context) error {
 		}
 
 		vaultConfig := secrets.VaultConfig{
-			Address:      vaultAddress,
-			Token:        vaultToken,
-			SecretPrefix: vaultSecretPath,
-			MountPath:    vaultMountPath,
-			AuthMethod:   vaultAuthMethod,
-			Role:         vaultRole,
-			Jwt:          vaultJwt,
+			Address:       vaultAddress,
+			Token:         vaultToken,
+			SecretPrefix:  vaultSecretPath,
+			MountPath:     vaultMountPath,
+			AuthMethod:    vaultAuthMethod,
+			AuthMountPath: vaultAuthMountPath,
+			Role:          vaultRole,
+			Jwt:           vaultJwt,
 		}
 
 		sm, err = secrets.NewHashicorpVaultService(ctx, log.Logger, vaultConfig)

--- a/cmd/httpserver/main.go
+++ b/cmd/httpserver/main.go
@@ -138,7 +138,7 @@ var flags = []cli.Flag{
 	&cli.StringFlag{
 		Name:    "vault-kubernetes-auth-path",
 		Value:   "",
-		Usage:   "Vault auth mount path for Kubernetes auth (e.g., 'k8s/eth-l1-prod', defaults to 'kubernetes')",
+		Usage:   "Vault auth mount path for Kubernetes auth (e.g., 'k8s/custom', defaults to 'kubernetes')",
 		EnvVars: []string{"VAULT_KUBERNETES_AUTH_PATH"},
 	},
 	&cli.StringFlag{

--- a/cmd/httpserver/main.go
+++ b/cmd/httpserver/main.go
@@ -138,7 +138,7 @@ var flags = []cli.Flag{
 	&cli.StringFlag{
 		Name:    "vault-kubernetes-auth-path",
 		Value:   "",
-		Usage:   "Vault auth mount path for Kubernetes auth (e.g., 'k8s/custom', defaults to 'kubernetes')",
+		Usage:   "Vault auth mount path for Kubernetes auth (e.g., 'k8s/custom', defaults to empty value)",
 		EnvVars: []string{"VAULT_KUBERNETES_AUTH_PATH"},
 	},
 	&cli.StringFlag{

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -98,6 +98,7 @@ services:
       VAULT_KUBERNETES_ROLE: "builder-hub"
       VAULT_KUBERNETES_JWT_PATH: "/var/run/secrets/kubernetes.io/serviceaccount/token"
       VAULT_MOUNT_PATH: "secret"
+      VAULT_KUBERNETES_AUTH_PATH: "k8s/custom"
       VAULT_SECRET_PATH: ""
       POSTGRES_DSN: "postgres://postgres:postgres@db:5432/postgres?sslmode=disable"
       LISTEN_ADDR: "0.0.0.0:8080"

--- a/docker/vault-init/init.sh
+++ b/docker/vault-init/init.sh
@@ -28,11 +28,11 @@ open("/vault-jwt/token", "w").write(token)
 print("SA JWT written to /vault-jwt/token")
 EOF
 
-# Enable Kubernetes auth method
-vault auth enable kubernetes
+# Enable Kubernetes auth method at custom path (matches VAULT_KUBERNETES_AUTH_PATH)
+vault auth enable -path=k8s/custom kubernetes
 
 # Configure Kubernetes auth to use mock-k8s for TokenReview (no real k8s API needed)
-vault write auth/kubernetes/config \
+vault write auth/k8s/custom/config \
     kubernetes_host="http://mock-k8s:8443" \
     disable_iss_validation=true \
     disable_local_ca_jwt=true
@@ -45,7 +45,7 @@ path "secret/*" {
 POLICY
 
 # Create a role for the builder-hub service account
-vault write auth/kubernetes/role/builder-hub \
+vault write auth/k8s/custom/role/builder-hub \
     bound_service_account_names="builder-hub" \
     bound_service_account_namespaces="default" \
     token_policies="default,builder-hub" \


### PR DESCRIPTION
## 📝 Summary

- Add `--vault-kubernetes-auth-path` option to configure the Vault K8s auth mount path (defaults to kubernetes). Required for setups where the auth backend is mounted at a custom path.
- Remove the startup Vault connectivity check that attempted to read the secret prefix path, which fails when the prefix is a directory, not a leaf secret.

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
