### PR TITLE
Fix proxy docker image build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,7 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v5
         with:
-          file: Dockerfile
+          file: ./docker/mock-proxy/Dockerfile
           context: ./docker/mock-proxy
           push: true
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
The workflow seems to accidentally use the Dockerfile for the builder-hub image. https://github.com/flashbots/builder-hub/actions/runs/24033641735/job/70087798322